### PR TITLE
NLTK API tweakage.

### DIFF
--- a/python/bllipparser/ParsingShell.py
+++ b/python/bllipparser/ParsingShell.py
@@ -16,12 +16,16 @@ import nltk.tree
 try:
     import nltk.draw.tree
     have_tree_drawing = False
-    read_nltk_tree = nltk.tree.Tree.fromstring
+    read_nltk_tree = nltk.tree.Tree.parse
     have_tree_drawing = True
 except ImportError:
     have_tree_drawing = False
 except AttributeError:
-    have_tree_drawing = False
+    try:
+        read_nltk_tree = nltk.tree.Tree.fromstring
+        have_tree_drawing = True
+    except AttributeError:
+        have_tree_drawing = False
 
 from bllipparser.RerankingParser import RerankingParser
 


### PR DESCRIPTION
When I tried to use the Python ParsingShell I had errors that seem to be due to an API change in NLTK.  nltk.tree.Tree.parse has apparently been removed/replaced by fromstring. There is bracket_parse too but its code says don't use it. Don't know if this is backward compatible but it works for me.
