### PR TITLE
Changes needed for compiling with clang under OS X

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -28,5 +28,6 @@ Contributors
 - `Ben Swanson <https://github.com/chonger>`__
 - Jenine Turner-Trauring
 - `Jim White <https://github.com/jimwhite>`__
+- `Didzis Gosko <https://github.com/didzis>`__
 
 (and many others with helpful bug reports and questions!)

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@
 #
 # GCCFLAGS = -march=native -mfpmath=sse -msse2 -mmmx -m32
 
+# Sample values for clang on Mac OS X
+#
+# GCCFLAGS="-Wno-deprecated-declarations"
+# FOPENMP="-liomp5"
+#
+# NOTE: libiomp needs to be installed, install using homebrew: brew install libiomp
+
 # CFLAGS is used for all C and C++ compilation
 #
 CFLAGS = -MMD -O3 -Wall -ffast-math -finline-functions -fomit-frame-pointer -fstrict-aliasing $(GCCFLAGS)

--- a/second-stage/programs/eval-beam/fdstream.hpp
+++ b/second-stage/programs/eval-beam/fdstream.hpp
@@ -1,0 +1,184 @@
+/* The following code declares classes to read from and write to
+ * file descriptore or file handles.
+ *
+ * See
+ *      http://www.josuttis.com/cppcode
+ * for details and the latest version.
+ *
+ * - open:
+ *      - integrating BUFSIZ on some systems?
+ *      - optimized reading of multiple characters
+ *      - stream for reading AND writing
+ *      - i18n
+ *
+ * (C) Copyright Nicolai M. Josuttis 2001.
+ * Permission to copy, use, modify, sell and distribute this software
+ * is granted provided this copyright notice appears in all copies.
+ * This software is provided "as is" without express or implied
+ * warranty, and with no claim as to its suitability for any purpose.
+ *
+ * Version: Jul 28, 2002
+ * History:
+ *  Jul 28, 2002: bugfix memcpy() => memmove()
+ *                fdinbuf::underflow(): cast for return statements
+ *  Aug 05, 2001: first public version
+ */
+#ifndef BOOST_FDSTREAM_HPP
+#define BOOST_FDSTREAM_HPP
+
+#include <istream>
+#include <ostream>
+#include <streambuf>
+// for EOF:
+#include <cstdio>
+// for memmove():
+#include <cstring>
+
+
+// low-level read and write functions
+#ifdef _MSC_VER
+# include <io.h>
+#else
+# include <unistd.h>
+//extern "C" {
+//    int write (int fd, const char* buf, int num);
+//    int read (int fd, char* buf, int num);
+//}
+#endif
+
+
+// BEGIN namespace BOOST
+namespace boost {
+
+
+/************************************************************
+ * fdostream
+ * - a stream that writes on a file descriptor
+ ************************************************************/
+
+
+class fdoutbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  public:
+    // constructor
+    fdoutbuf (int _fd) : fd(_fd) {
+    }
+  protected:
+    // write one character
+    virtual int_type overflow (int_type c) {
+        if (c != EOF) {
+            char z = c;
+            if (write (fd, &z, 1) != 1) {
+                return EOF;
+            }
+        }
+        return c;
+    }
+    // write multiple characters
+    virtual
+    std::streamsize xsputn (const char* s,
+                            std::streamsize num) {
+        return write(fd,s,num);
+    }
+};
+
+class fdostream : public std::ostream {
+  protected:
+    fdoutbuf buf;
+  public:
+    fdostream (int fd) : std::ostream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+/************************************************************
+ * fdistream
+ * - a stream that reads on a file descriptor
+ ************************************************************/
+
+class fdinbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  protected:
+    /* data buffer:
+     * - at most, pbSize characters in putback area plus
+     * - at most, bufSize characters in ordinary read buffer
+     */
+    static const int pbSize = 4;        // size of putback area
+    static const int bufSize = 1024;    // size of the data buffer
+    char buffer[bufSize+pbSize];        // data buffer
+
+  public:
+    /* constructor
+     * - initialize file descriptor
+     * - initialize empty data buffer
+     * - no putback area
+     * => force underflow()
+     */
+    fdinbuf (int _fd) : fd(_fd) {
+        setg (buffer+pbSize,     // beginning of putback area
+              buffer+pbSize,     // read position
+              buffer+pbSize);    // end position
+    }
+
+  protected:
+    // insert new characters into the buffer
+    virtual int_type underflow () {
+#ifndef _MSC_VER
+        using std::memmove;
+#endif
+
+        // is read position before end of buffer?
+        if (gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        /* process size of putback area
+         * - use number of characters read
+         * - but at most size of putback area
+         */
+        int numPutback;
+        numPutback = gptr() - eback();
+        if (numPutback > pbSize) {
+            numPutback = pbSize;
+        }
+
+        /* copy up to pbSize characters previously read into
+         * the putback area
+         */
+        memmove (buffer+(pbSize-numPutback), gptr()-numPutback,
+                numPutback);
+
+        // read at most bufSize new characters
+        int num;
+        num = read (fd, buffer+pbSize, bufSize);
+        if (num <= 0) {
+            // ERROR or EOF
+            return EOF;
+        }
+
+        // reset buffer pointers
+        setg (buffer+(pbSize-numPutback),   // beginning of putback area
+              buffer+pbSize,                // read position
+              buffer+pbSize+num);           // end of buffer
+
+        // return next character
+        return traits_type::to_int_type(*gptr());
+    }
+};
+
+class fdistream : public std::istream {
+  protected:
+    fdinbuf buf;
+  public:
+    fdistream (int fd) : std::istream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+} // END namespace boost
+
+#endif /*BOOST_FDSTREAM_HPP*/

--- a/second-stage/programs/eval-beam/popen.h
+++ b/second-stage/programs/eval-beam/popen.h
@@ -22,7 +22,11 @@
 
 #include <cstdio>
 #include <cstring>
+#ifdef __clang__
+#include "fdstream.hpp"
+#else
 #include <ext/stdio_filebuf.h>
+#endif
 #include <iostream>
 #include <string>
 
@@ -31,10 +35,17 @@
 //
 struct ipstream_helper {
   FILE* stdio_fp;
+#ifdef __clang__
+  boost::fdinbuf stdio_fb;
+
+  ipstream_helper(const char* command)
+    : stdio_fp(popen(command, "r")), stdio_fb(fileno(stdio_fp)) { }
+#else
   __gnu_cxx::stdio_filebuf<char> stdio_fb;
 
   ipstream_helper(const char* command) 
     : stdio_fp(popen(command, "r")), stdio_fb(stdio_fp, std::ios_base::in) { }
+#endif
 
   ~ipstream_helper() { pclose(stdio_fp); }  // close the popen'd stream
 }; // ipstream_helper{}

--- a/second-stage/programs/eval-beam/tree.h
+++ b/second-stage/programs/eval-beam/tree.h
@@ -1098,7 +1098,7 @@ void map_filenamefile_trees(const char* filenamefile, Proc& proc, bool downcase_
     readtree_lineno = 1;
 
     std::auto_ptr<tree> tp;
-    while ((tp = readtree_root(fp, downcase_flag)).get()) 
+    while ((tp = std::auto_ptr<tree>(readtree_root(fp, downcase_flag))).get())
       proc(tp.get());
 
     fclose(fp);

--- a/second-stage/programs/eval-beam/utility.h
+++ b/second-stage/programs/eval-beam/utility.h
@@ -52,7 +52,11 @@
 #include <cstdio>
 #include <ext/hash_map>
 #include <ext/hash_set>
+#ifdef __clang__
+#include <forward_list>
+#else
 #include <ext/slist>
+#endif
 #include <iostream>
 #include <iterator>
 #include <list>
@@ -70,6 +74,12 @@
 #endif
 
 namespace ext = EXT_NAMESPACE;
+
+#ifdef __clang__
+namespace EXT_NAMESPACE {
+	template <class T> using slist = std::forward_list<T>;
+}
+#endif
 
 // define some useful macros
 

--- a/second-stage/programs/eval-weights/fdstream.hpp
+++ b/second-stage/programs/eval-weights/fdstream.hpp
@@ -1,0 +1,184 @@
+/* The following code declares classes to read from and write to
+ * file descriptore or file handles.
+ *
+ * See
+ *      http://www.josuttis.com/cppcode
+ * for details and the latest version.
+ *
+ * - open:
+ *      - integrating BUFSIZ on some systems?
+ *      - optimized reading of multiple characters
+ *      - stream for reading AND writing
+ *      - i18n
+ *
+ * (C) Copyright Nicolai M. Josuttis 2001.
+ * Permission to copy, use, modify, sell and distribute this software
+ * is granted provided this copyright notice appears in all copies.
+ * This software is provided "as is" without express or implied
+ * warranty, and with no claim as to its suitability for any purpose.
+ *
+ * Version: Jul 28, 2002
+ * History:
+ *  Jul 28, 2002: bugfix memcpy() => memmove()
+ *                fdinbuf::underflow(): cast for return statements
+ *  Aug 05, 2001: first public version
+ */
+#ifndef BOOST_FDSTREAM_HPP
+#define BOOST_FDSTREAM_HPP
+
+#include <istream>
+#include <ostream>
+#include <streambuf>
+// for EOF:
+#include <cstdio>
+// for memmove():
+#include <cstring>
+
+
+// low-level read and write functions
+#ifdef _MSC_VER
+# include <io.h>
+#else
+# include <unistd.h>
+//extern "C" {
+//    int write (int fd, const char* buf, int num);
+//    int read (int fd, char* buf, int num);
+//}
+#endif
+
+
+// BEGIN namespace BOOST
+namespace boost {
+
+
+/************************************************************
+ * fdostream
+ * - a stream that writes on a file descriptor
+ ************************************************************/
+
+
+class fdoutbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  public:
+    // constructor
+    fdoutbuf (int _fd) : fd(_fd) {
+    }
+  protected:
+    // write one character
+    virtual int_type overflow (int_type c) {
+        if (c != EOF) {
+            char z = c;
+            if (write (fd, &z, 1) != 1) {
+                return EOF;
+            }
+        }
+        return c;
+    }
+    // write multiple characters
+    virtual
+    std::streamsize xsputn (const char* s,
+                            std::streamsize num) {
+        return write(fd,s,num);
+    }
+};
+
+class fdostream : public std::ostream {
+  protected:
+    fdoutbuf buf;
+  public:
+    fdostream (int fd) : std::ostream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+/************************************************************
+ * fdistream
+ * - a stream that reads on a file descriptor
+ ************************************************************/
+
+class fdinbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  protected:
+    /* data buffer:
+     * - at most, pbSize characters in putback area plus
+     * - at most, bufSize characters in ordinary read buffer
+     */
+    static const int pbSize = 4;        // size of putback area
+    static const int bufSize = 1024;    // size of the data buffer
+    char buffer[bufSize+pbSize];        // data buffer
+
+  public:
+    /* constructor
+     * - initialize file descriptor
+     * - initialize empty data buffer
+     * - no putback area
+     * => force underflow()
+     */
+    fdinbuf (int _fd) : fd(_fd) {
+        setg (buffer+pbSize,     // beginning of putback area
+              buffer+pbSize,     // read position
+              buffer+pbSize);    // end position
+    }
+
+  protected:
+    // insert new characters into the buffer
+    virtual int_type underflow () {
+#ifndef _MSC_VER
+        using std::memmove;
+#endif
+
+        // is read position before end of buffer?
+        if (gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        /* process size of putback area
+         * - use number of characters read
+         * - but at most size of putback area
+         */
+        int numPutback;
+        numPutback = gptr() - eback();
+        if (numPutback > pbSize) {
+            numPutback = pbSize;
+        }
+
+        /* copy up to pbSize characters previously read into
+         * the putback area
+         */
+        memmove (buffer+(pbSize-numPutback), gptr()-numPutback,
+                numPutback);
+
+        // read at most bufSize new characters
+        int num;
+        num = read (fd, buffer+pbSize, bufSize);
+        if (num <= 0) {
+            // ERROR or EOF
+            return EOF;
+        }
+
+        // reset buffer pointers
+        setg (buffer+(pbSize-numPutback),   // beginning of putback area
+              buffer+pbSize,                // read position
+              buffer+pbSize+num);           // end of buffer
+
+        // return next character
+        return traits_type::to_int_type(*gptr());
+    }
+};
+
+class fdistream : public std::istream {
+  protected:
+    fdinbuf buf;
+  public:
+    fdistream (int fd) : std::istream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+} // END namespace boost
+
+#endif /*BOOST_FDSTREAM_HPP*/

--- a/second-stage/programs/eval-weights/lmdata.c
+++ b/second-stage/programs/eval-weights/lmdata.c
@@ -468,7 +468,9 @@ corpus_type *read_corpus_file(corpusflags_type *flags, const char* filename) {
  *! last highest scoring parse.
  */
 
+#ifndef __clang__
 __inline__
+#endif
 void sentence_scores(sentence_type *s, const Float w[], Float score[],
 		     Float *best_correct_score, int *best_correct_i,
 		     Float *best_score, int *best_i) {
@@ -1000,7 +1002,9 @@ Float exp_corpus_stats(corpus_type *c, const Float w[], Float dL_dw[],
  *! Returns the index of the last highest scoring parse.
  */
 
+#ifndef __clang__
 __inline__
+#endif
 int sentence_Pyx(sentence_type *s, const Float w[], Float Py_x[]) {
   
   int i, n = s->nparses, best_i = 0;

--- a/second-stage/programs/eval-weights/popen.h
+++ b/second-stage/programs/eval-weights/popen.h
@@ -21,6 +21,10 @@
 #define POPEN_H
 
 #include <cstdio>
+#include <cstring>
+#ifdef __clang__
+#include "fdstream.hpp"
+#else
 #include <ext/stdio_filebuf.h>
 #include <iostream>
 #include <string>
@@ -30,10 +34,17 @@
 //
 struct ipstream_helper {
   FILE* stdio_fp;
+#ifdef __clang__
+  boost::fdinbuf stdio_fb;
+
+  ipstream_helper(const char* command)
+    : stdio_fp(popen(command, "r")), stdio_fb(fileno(stdio_fp)) { }
+#else
   __gnu_cxx::stdio_filebuf<char> stdio_fb;
 
   ipstream_helper(const char* command) 
     : stdio_fp(popen(command, "r")), stdio_fb(stdio_fp, std::ios_base::in) { }
+#endif
 
   ~ipstream_helper() { pclose(stdio_fp); }  // close the popen'd stream
 }; // ipstream_helper{}

--- a/second-stage/programs/eval-weights/tree.h
+++ b/second-stage/programs/eval-weights/tree.h
@@ -1098,7 +1098,7 @@ void map_filenamefile_trees(const char* filenamefile, Proc& proc, bool downcase_
     readtree_lineno = 1;
 
     std::auto_ptr<tree> tp;
-    while ((tp = readtree_root(fp, downcase_flag)).get()) 
+    while ((tp = std::auto_ptr<tree>(readtree_root(fp, downcase_flag))).get())
       proc(tp.get());
 
     fclose(fp);

--- a/second-stage/programs/eval-weights/utility.h
+++ b/second-stage/programs/eval-weights/utility.h
@@ -51,7 +51,11 @@
 #include <cstdio>
 #include <ext/hash_map>
 #include <ext/hash_set>
+#ifdef __clang__
+#include <forward_list>
+#else
 #include <ext/slist>
+#endif
 #include <iostream>
 #include <iterator>
 #include <list>
@@ -70,6 +74,11 @@
 
 namespace ext = EXT_NAMESPACE;
 
+#ifdef __clang__
+namespace EXT_NAMESPACE {
+	template <class T> using slist = std::forward_list<T>;
+}
+#endif
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //
 //                              Looping constructs                       //

--- a/second-stage/programs/features/Makefile
+++ b/second-stage/programs/features/Makefile
@@ -15,7 +15,7 @@ SOURCES = best-parses.cc best-splhparses.cc best-spmparses.cc extract-spmultifea
 OBJECTS = $(patsubst %.l,%.o,$(patsubst %.c,%.o,$(SOURCES:%.cc=%.o)))
 PARALLEL_TOOLS_TARGETS = count-spfeatures count-nfeatures parallel-extract-nfeatures parallel-extract-spfeatures
 
-FOPENMP=-fopenmp
+FOPENMP?=-fopenmp
 
 top: $(TARGETS)
 

--- a/second-stage/programs/features/fdstream.hpp
+++ b/second-stage/programs/features/fdstream.hpp
@@ -1,0 +1,184 @@
+/* The following code declares classes to read from and write to
+ * file descriptore or file handles.
+ *
+ * See
+ *      http://www.josuttis.com/cppcode
+ * for details and the latest version.
+ *
+ * - open:
+ *      - integrating BUFSIZ on some systems?
+ *      - optimized reading of multiple characters
+ *      - stream for reading AND writing
+ *      - i18n
+ *
+ * (C) Copyright Nicolai M. Josuttis 2001.
+ * Permission to copy, use, modify, sell and distribute this software
+ * is granted provided this copyright notice appears in all copies.
+ * This software is provided "as is" without express or implied
+ * warranty, and with no claim as to its suitability for any purpose.
+ *
+ * Version: Jul 28, 2002
+ * History:
+ *  Jul 28, 2002: bugfix memcpy() => memmove()
+ *                fdinbuf::underflow(): cast for return statements
+ *  Aug 05, 2001: first public version
+ */
+#ifndef BOOST_FDSTREAM_HPP
+#define BOOST_FDSTREAM_HPP
+
+#include <istream>
+#include <ostream>
+#include <streambuf>
+// for EOF:
+#include <cstdio>
+// for memmove():
+#include <cstring>
+
+
+// low-level read and write functions
+#ifdef _MSC_VER
+# include <io.h>
+#else
+# include <unistd.h>
+//extern "C" {
+//    int write (int fd, const char* buf, int num);
+//    int read (int fd, char* buf, int num);
+//}
+#endif
+
+
+// BEGIN namespace BOOST
+namespace boost {
+
+
+/************************************************************
+ * fdostream
+ * - a stream that writes on a file descriptor
+ ************************************************************/
+
+
+class fdoutbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  public:
+    // constructor
+    fdoutbuf (int _fd) : fd(_fd) {
+    }
+  protected:
+    // write one character
+    virtual int_type overflow (int_type c) {
+        if (c != EOF) {
+            char z = c;
+            if (write (fd, &z, 1) != 1) {
+                return EOF;
+            }
+        }
+        return c;
+    }
+    // write multiple characters
+    virtual
+    std::streamsize xsputn (const char* s,
+                            std::streamsize num) {
+        return write(fd,s,num);
+    }
+};
+
+class fdostream : public std::ostream {
+  protected:
+    fdoutbuf buf;
+  public:
+    fdostream (int fd) : std::ostream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+/************************************************************
+ * fdistream
+ * - a stream that reads on a file descriptor
+ ************************************************************/
+
+class fdinbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  protected:
+    /* data buffer:
+     * - at most, pbSize characters in putback area plus
+     * - at most, bufSize characters in ordinary read buffer
+     */
+    static const int pbSize = 4;        // size of putback area
+    static const int bufSize = 1024;    // size of the data buffer
+    char buffer[bufSize+pbSize];        // data buffer
+
+  public:
+    /* constructor
+     * - initialize file descriptor
+     * - initialize empty data buffer
+     * - no putback area
+     * => force underflow()
+     */
+    fdinbuf (int _fd) : fd(_fd) {
+        setg (buffer+pbSize,     // beginning of putback area
+              buffer+pbSize,     // read position
+              buffer+pbSize);    // end position
+    }
+
+  protected:
+    // insert new characters into the buffer
+    virtual int_type underflow () {
+#ifndef _MSC_VER
+        using std::memmove;
+#endif
+
+        // is read position before end of buffer?
+        if (gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        /* process size of putback area
+         * - use number of characters read
+         * - but at most size of putback area
+         */
+        int numPutback;
+        numPutback = gptr() - eback();
+        if (numPutback > pbSize) {
+            numPutback = pbSize;
+        }
+
+        /* copy up to pbSize characters previously read into
+         * the putback area
+         */
+        memmove (buffer+(pbSize-numPutback), gptr()-numPutback,
+                numPutback);
+
+        // read at most bufSize new characters
+        int num;
+        num = read (fd, buffer+pbSize, bufSize);
+        if (num <= 0) {
+            // ERROR or EOF
+            return EOF;
+        }
+
+        // reset buffer pointers
+        setg (buffer+(pbSize-numPutback),   // beginning of putback area
+              buffer+pbSize,                // read position
+              buffer+pbSize+num);           // end of buffer
+
+        // return next character
+        return traits_type::to_int_type(*gptr());
+    }
+};
+
+class fdistream : public std::istream {
+  protected:
+    fdinbuf buf;
+  public:
+    fdistream (int fd) : std::istream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+} // END namespace boost
+
+#endif /*BOOST_FDSTREAM_HPP*/

--- a/second-stage/programs/features/popen.h
+++ b/second-stage/programs/features/popen.h
@@ -22,7 +22,11 @@
 
 #include <cstdio>
 #include <cstring>
+#ifdef __clang__
+#include "fdstream.hpp"
+#else
 #include <ext/stdio_filebuf.h>
+#endif
 #include <iostream>
 #include <string>
 
@@ -31,10 +35,17 @@
 //
 struct ipstream_helper {
   FILE* stdio_fp;
+#ifdef __clang__
+  boost::fdinbuf stdio_fb;
+
+  ipstream_helper(const char* command)
+    : stdio_fp(popen(command, "r")), stdio_fb(fileno(stdio_fp)) { }
+#else
   __gnu_cxx::stdio_filebuf<char> stdio_fb;
 
   ipstream_helper(const char* command) 
     : stdio_fp(popen(command, "r")), stdio_fb(stdio_fp, std::ios_base::in) { }
+#endif
 
   ~ipstream_helper() { pclose(stdio_fp); }  // close the popen'd stream
 }; // ipstream_helper{}

--- a/second-stage/programs/features/tree.h
+++ b/second-stage/programs/features/tree.h
@@ -1099,7 +1099,7 @@ void map_filenamefile_trees(const char* filenamefile, Proc& proc, bool downcase_
     readtree_lineno = 1;
 
     std::auto_ptr<tree> tp;
-    while ((tp = readtree_root(fp, downcase_flag)).get()) 
+    while ((tp = std::auto_ptr<tree>(readtree_root(fp, downcase_flag))).get())
       proc(tp.get());
 
     fclose(fp);

--- a/second-stage/programs/prepare-data/fdstream.hpp
+++ b/second-stage/programs/prepare-data/fdstream.hpp
@@ -1,0 +1,184 @@
+/* The following code declares classes to read from and write to
+ * file descriptore or file handles.
+ *
+ * See
+ *      http://www.josuttis.com/cppcode
+ * for details and the latest version.
+ *
+ * - open:
+ *      - integrating BUFSIZ on some systems?
+ *      - optimized reading of multiple characters
+ *      - stream for reading AND writing
+ *      - i18n
+ *
+ * (C) Copyright Nicolai M. Josuttis 2001.
+ * Permission to copy, use, modify, sell and distribute this software
+ * is granted provided this copyright notice appears in all copies.
+ * This software is provided "as is" without express or implied
+ * warranty, and with no claim as to its suitability for any purpose.
+ *
+ * Version: Jul 28, 2002
+ * History:
+ *  Jul 28, 2002: bugfix memcpy() => memmove()
+ *                fdinbuf::underflow(): cast for return statements
+ *  Aug 05, 2001: first public version
+ */
+#ifndef BOOST_FDSTREAM_HPP
+#define BOOST_FDSTREAM_HPP
+
+#include <istream>
+#include <ostream>
+#include <streambuf>
+// for EOF:
+#include <cstdio>
+// for memmove():
+#include <cstring>
+
+
+// low-level read and write functions
+#ifdef _MSC_VER
+# include <io.h>
+#else
+# include <unistd.h>
+//extern "C" {
+//    int write (int fd, const char* buf, int num);
+//    int read (int fd, char* buf, int num);
+//}
+#endif
+
+
+// BEGIN namespace BOOST
+namespace boost {
+
+
+/************************************************************
+ * fdostream
+ * - a stream that writes on a file descriptor
+ ************************************************************/
+
+
+class fdoutbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  public:
+    // constructor
+    fdoutbuf (int _fd) : fd(_fd) {
+    }
+  protected:
+    // write one character
+    virtual int_type overflow (int_type c) {
+        if (c != EOF) {
+            char z = c;
+            if (write (fd, &z, 1) != 1) {
+                return EOF;
+            }
+        }
+        return c;
+    }
+    // write multiple characters
+    virtual
+    std::streamsize xsputn (const char* s,
+                            std::streamsize num) {
+        return write(fd,s,num);
+    }
+};
+
+class fdostream : public std::ostream {
+  protected:
+    fdoutbuf buf;
+  public:
+    fdostream (int fd) : std::ostream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+/************************************************************
+ * fdistream
+ * - a stream that reads on a file descriptor
+ ************************************************************/
+
+class fdinbuf : public std::streambuf {
+  protected:
+    int fd;    // file descriptor
+  protected:
+    /* data buffer:
+     * - at most, pbSize characters in putback area plus
+     * - at most, bufSize characters in ordinary read buffer
+     */
+    static const int pbSize = 4;        // size of putback area
+    static const int bufSize = 1024;    // size of the data buffer
+    char buffer[bufSize+pbSize];        // data buffer
+
+  public:
+    /* constructor
+     * - initialize file descriptor
+     * - initialize empty data buffer
+     * - no putback area
+     * => force underflow()
+     */
+    fdinbuf (int _fd) : fd(_fd) {
+        setg (buffer+pbSize,     // beginning of putback area
+              buffer+pbSize,     // read position
+              buffer+pbSize);    // end position
+    }
+
+  protected:
+    // insert new characters into the buffer
+    virtual int_type underflow () {
+#ifndef _MSC_VER
+        using std::memmove;
+#endif
+
+        // is read position before end of buffer?
+        if (gptr() < egptr()) {
+            return traits_type::to_int_type(*gptr());
+        }
+
+        /* process size of putback area
+         * - use number of characters read
+         * - but at most size of putback area
+         */
+        int numPutback;
+        numPutback = gptr() - eback();
+        if (numPutback > pbSize) {
+            numPutback = pbSize;
+        }
+
+        /* copy up to pbSize characters previously read into
+         * the putback area
+         */
+        memmove (buffer+(pbSize-numPutback), gptr()-numPutback,
+                numPutback);
+
+        // read at most bufSize new characters
+        int num;
+        num = read (fd, buffer+pbSize, bufSize);
+        if (num <= 0) {
+            // ERROR or EOF
+            return EOF;
+        }
+
+        // reset buffer pointers
+        setg (buffer+(pbSize-numPutback),   // beginning of putback area
+              buffer+pbSize,                // read position
+              buffer+pbSize+num);           // end of buffer
+
+        // return next character
+        return traits_type::to_int_type(*gptr());
+    }
+};
+
+class fdistream : public std::istream {
+  protected:
+    fdinbuf buf;
+  public:
+    fdistream (int fd) : std::istream(0), buf(fd) {
+        rdbuf(&buf);
+    }
+};
+
+
+} // END namespace boost
+
+#endif /*BOOST_FDSTREAM_HPP*/

--- a/second-stage/programs/prepare-data/popen.h
+++ b/second-stage/programs/prepare-data/popen.h
@@ -22,7 +22,11 @@
 
 #include <cstdio>
 #include <cstring>
+#ifdef __clang__
+#include "fdstream.hpp"
+#else
 #include <ext/stdio_filebuf.h>
+#endif
 #include <iostream>
 #include <string>
 
@@ -31,10 +35,17 @@
 //
 struct ipstream_helper {
   FILE* stdio_fp;
+#ifdef __clang__
+  boost::fdinbuf stdio_fb;
+
+  ipstream_helper(const char* command)
+    : stdio_fp(popen(command, "r")), stdio_fb(fileno(stdio_fp)) { }
+#else
   __gnu_cxx::stdio_filebuf<char> stdio_fb;
 
   ipstream_helper(const char* command) 
     : stdio_fp(popen(command, "r")), stdio_fb(stdio_fp, std::ios_base::in) { }
+#endif
 
   ~ipstream_helper() { pclose(stdio_fp); }  // close the popen'd stream
 }; // ipstream_helper{}

--- a/second-stage/programs/prepare-data/tree.h
+++ b/second-stage/programs/prepare-data/tree.h
@@ -1098,7 +1098,7 @@ void map_filenamefile_trees(const char* filenamefile, Proc& proc, bool downcase_
     readtree_lineno = 1;
 
     std::auto_ptr<tree> tp;
-    while ((tp = readtree_root(fp, downcase_flag)).get()) 
+    while ((tp = std::auto_ptr<tree>(readtree_root(fp, downcase_flag))).get())
       proc(tp.get());
 
     fclose(fp);

--- a/second-stage/programs/prepare-data/utility.h
+++ b/second-stage/programs/prepare-data/utility.h
@@ -51,7 +51,11 @@
 #include <cstdio>
 #include <ext/hash_map>
 #include <ext/hash_set>
+#ifdef __clang__
+#include <forward_list>
+#else
 #include <ext/slist>
+#endif
 #include <iostream>
 #include <iterator>
 #include <list>
@@ -69,6 +73,12 @@
 #endif
 
 namespace ext = EXT_NAMESPACE;
+
+#ifdef __clang__
+namespace EXT_NAMESPACE {
+	template <class T> using slist = std::forward_list<T>;
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //

--- a/second-stage/programs/wlle/Makefile
+++ b/second-stage/programs/wlle/Makefile
@@ -51,7 +51,7 @@ CC=gcc
 # fast options
 # Compilation help: you may need to remove -march=native on older compilers.
 GCCFLAGS=-march=native -mfpmath=sse -msse2 -mmmx
-FOPENMP=-fopenmp
+FOPENMP?=-fopenmp
 CFLAGS=-MMD -O3 -ffast-math -fstrict-aliasing -Wall -finline-functions $(GCCFLAGS) $(FOPENMP)
 LDFLAGS=$(FOPENMP)
 CXXFLAGS=${CFLAGS} -Wno-deprecated

--- a/second-stage/programs/wlle/gavper.cc
+++ b/second-stage/programs/wlle/gavper.cc
@@ -27,9 +27,9 @@
 #include <unistd.h>
 #include <vector>
 
+#include "utility.h"
 #include "greedy.h"
 #include "lmdata.h"
-#include "utility.h"
 
 const char usage[] =
 "gavper version of 1st August 2008\n"

--- a/second-stage/programs/wlle/lmdata.c
+++ b/second-stage/programs/wlle/lmdata.c
@@ -74,7 +74,9 @@ Float parse_score(const parse_type *p, const Float w[]) {
  *! last highest scoring parse.
  */
 
+#ifndef __clang__
 __inline__
+#endif
 void sentence_scores(sentence_type *s, const Float w[], Float score[],
 		     Float *best_correct_score, int *best_correct_i,
 		     Float *best_score, int *best_i) {
@@ -1108,7 +1110,9 @@ Float exp_corpus_stats(corpus_type *c, const Float w[], Float dL_dw[],
  *! Returns the index of the last highest scoring parse.
  */
 
+#ifndef __clang__
 __inline__
+#endif
 int sentence_Pyx(sentence_type *s, const Float w[], Float Py_x[]) {
   
   int i, n = s->nparses, best_i = 0;

--- a/second-stage/programs/wlle/utility.h
+++ b/second-stage/programs/wlle/utility.h
@@ -51,7 +51,11 @@
 #include <cstdio>
 #include <ext/hash_map>
 #include <ext/hash_set>
+#ifdef __clang__
+#include <forward_list>
+#else
 #include <ext/slist>
+#endif
 #include <iostream>
 #include <iterator>
 #include <list>
@@ -69,6 +73,12 @@
 #endif
 
 namespace ext = EXT_NAMESPACE;
+
+#ifdef __clang__
+namespace EXT_NAMESPACE {
+	template <class T> using slist = std::forward_list<T>;
+}
+#endif
 
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //


### PR DESCRIPTION
As clang doesn't have OpenMP implementation, installation of libiomp is needed; can be done using homebrew:

```
$ brew install libiomp
```

FOPENMP environment variable should be set, for example, from command line:

```
$ FOPENMP="-liomp5" make
```

GNU stdio_filebuf API is replaced with portable version from here: http://www.josuttis.com/cppcode/fdstream.hpp
Other small changes made, so that clang will compile.
Tested under Yosemite with clang version: Apple LLVM version 7.0.0 (clang-700.0.72)
No GCC installation needed.
